### PR TITLE
cambios en la configuracion CORS

### DIFF
--- a/backend/src/main/java/com/example/backend/config/CorsConfig.java
+++ b/backend/src/main/java/com/example/backend/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package com.example.backend.config;
 
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,13 +8,24 @@ import org.springframework.web.cors.*;
 
 @Configuration
 public class CorsConfig {
+
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration cfg = new CorsConfiguration();
-    cfg.setAllowedOrigins(List.of("http://localhost:5173"));
-    cfg.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
-    cfg.setAllowedHeaders(List.of("Content-Type","Authorization"));
+
+    // Orígenes exactos (con puerto). No usar "*" si allowCredentials=true
+    cfg.setAllowedOriginPatterns(Arrays.asList(
+        "http://localhost:5173",
+        "http://127.0.0.1:5173"
+    ));
     cfg.setAllowCredentials(true);
+
+    // Métodos y cabeceras que aceptamos en el preflight
+    cfg.setAllowedMethods(Arrays.asList("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+    cfg.setAllowedHeaders(Arrays.asList("*")); // acepta Content-Type, Authorization, etc.
+    cfg.setExposedHeaders(Arrays.asList("Location", "Set-Cookie"));
+    cfg.setMaxAge(3600L);
+
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", cfg);
     return source;

--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.backend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -20,6 +21,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .cors(Customizer.withDefaults()) // activar CORS
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // <- preflight
                 .requestMatchers("/auth/**").permitAll()
                 .requestMatchers("/profile", "/profile/**").permitAll()
                 .requestMatchers("/events", "/events/**").permitAll() 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,2 @@
 # API base url used by the frontend.
-VITE_API_BASE=http://localhost:4000
+VITE_API_BASE=http://localhost:8080 #canviar de 4000 a 8080 si cal

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,13 @@
 const API_BASE = import.meta.env.VITE_API_BASE || ''
 
+console.log('[API] VITE_API_BASE =', import.meta.env.VITE_API_BASE);
+console.log('[API] API_BASE =', API_BASE);
+
+
 async function request(path, { method = 'GET', body, headers = {}, credentials = 'include' } = {}) {
   const url = API_BASE + path
+  console.log(`[API] ${method} ->`, url); 
+
   const opts = {
     method,
     headers: {


### PR DESCRIPTION
Cambio de URL API base en el frontend.

Ajuste de la configuaracion de CORS:
Como hacemos uso de cookies siempre pondremos Access-Control-Allow-Credentials: true

**Ademas hay que crear en la raíz de frontend un archivo llamado .env.local con el contenido `VITE_API_BASE=http://localhost:8080
`para que localmente se tenga en cuenta esa variable a la hora de ejecutar.**

También se ha añadido un console.log para tener claro el puerto que se está usando.

