### PR TITLE
feat: Add user profile and sports management

### DIFF
--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -24,6 +24,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // <- preflight
                 .requestMatchers("/", "/auth/**").permitAll() 
                 .requestMatchers("/profile", "/profile/**").permitAll()
+                .requestMatchers("/users/**").permitAll()
+                .requestMatchers("/sports/**").permitAll()
                 .requestMatchers("/events", "/events/**").permitAll() 
                 .anyRequest().authenticated()
                 

--- a/backend/src/main/java/com/example/backend/controller/ConfigurarPerfilController.java
+++ b/backend/src/main/java/com/example/backend/controller/ConfigurarPerfilController.java
@@ -1,23 +1,65 @@
 package com.example.backend.controller;
 
-import org.springframework.http.ResponseEntity;
+import com.example.backend.model.User;
+import com.example.backend.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
-import java.util.*;
+
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/profile")
 public class ConfigurarPerfilController {
-
-    @PostMapping
-    public ResponseEntity<?> configurarPerfil(@RequestBody Map<String, List<Map<String, String>>> body) {
-        List<Map<String, String>> sportsList = body.get("sports");
-        if (sportsList == null || sportsList.isEmpty()) {
-            return ResponseEntity.badRequest().body(Map.of(
-                "message", "Validation failed",
-                "errors", Map.of("sports", "Select at least one sport")
-            ));
+    
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+    
+    public ConfigurarPerfilController(UserRepository userRepository, ObjectMapper objectMapper) {
+        this.userRepository = userRepository;
+        this.objectMapper = objectMapper;
+    }
+    
+    @PostMapping("/{userId}")
+    public ResponseEntity<?> configurarPerfil(
+            @PathVariable Long userId,
+            @RequestBody Map<String, Object> body) {
+        
+        try {
+            // Validar que sports existe y no está vacío
+            List<?> sportsList = (List<?>) body.get("sports");
+            if (sportsList == null || sportsList.isEmpty()) {
+                return ResponseEntity.badRequest().body(Map.of(
+                    "message", "Validation failed",
+                    "errors", Map.of("sports", "Select at least one sport")
+                ));
+            }
+            
+            return userRepository.findById(userId)
+                .map(user -> {
+                    try {
+                        String sportsJson = objectMapper.writeValueAsString(sportsList);
+                        user.setSports(sportsJson);
+                        
+                        if (body.containsKey("bio")) {
+                            user.setBio((String) body.get("bio"));
+                        }
+                        if (body.containsKey("profileImage")) {
+                            user.setProfileImage((String) body.get("profileImage"));
+                        }
+                        
+                        userRepository.save(user);
+                        return ResponseEntity.ok(Map.of("message", "Profile saved"));
+                    } catch (Exception e) {
+                        return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+                    }
+                })
+                .orElse(ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "User not found")));
+                    
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         }
-
-        return ResponseEntity.ok(Map.of("message", "Profile saved"));
     }
 }

--- a/backend/src/main/java/com/example/backend/controller/SportsController.java
+++ b/backend/src/main/java/com/example/backend/controller/SportsController.java
@@ -1,0 +1,60 @@
+package com.example.backend.controller;
+
+import com.example.backend.model.UserSport;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/sports")
+@CrossOrigin(origins = "http://localhost:5173")
+public class SportsController {
+    
+    private static final List<String> AVAILABLE_SPORTS = Arrays.asList(
+        "futbol",
+        "basquet",
+        "tenis",
+        "natacio",
+        "ciclisme",
+        "correr",
+        "gimnasia",
+        "senderisme",
+        "padel",
+        "surf"
+    );
+    
+    @GetMapping
+    public ResponseEntity<?> getSports() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("sports", AVAILABLE_SPORTS);
+        response.put("levels", getSportLevelsList());
+        response.put("total_sports", AVAILABLE_SPORTS.size());
+        response.put("total_levels", getSportLevelsList().size());
+        return ResponseEntity.ok(response);
+    }
+    
+    @GetMapping("/levels")
+    public ResponseEntity<?> getSportLevels() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("levels", getSportLevelsList());
+        return ResponseEntity.ok(response);
+    }
+    
+    @GetMapping("/available")
+    public ResponseEntity<?> getAvailableSports() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("sports", AVAILABLE_SPORTS);
+        return ResponseEntity.ok(response);
+    }
+    
+    private List<String> getSportLevelsList() {
+        return Arrays.stream(UserSport.Level.values())
+            .map(Enum::name)
+            .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/example/backend/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.example.backend.controller;
+
+import com.example.backend.model.User;
+import com.example.backend.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/users")
+@CrossOrigin(origins = "http://localhost:5173")
+public class UserController {
+    
+    private final UserRepository userRepository;
+    
+    public UserController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+    
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> getUserById(@PathVariable Long userId) {
+        return userRepository.findById(userId)
+            .map(user -> {
+                Map<String, Object> response = new HashMap<>();
+                response.put("id", user.getId());
+                response.put("username", user.getUsername());
+                response.put("email", user.getEmail());
+                response.put("sports", user.getSports());
+                response.put("bio", user.getBio());
+                response.put("profileImage", user.getProfileImage());
+                response.put("createdAt", user.getCreatedAt());
+                return ResponseEntity.ok(response);
+            })
+            .orElse(ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", "User not found")));
+    }
+}

--- a/backend/src/main/java/com/example/backend/dto/UserResponse.java
+++ b/backend/src/main/java/com/example/backend/dto/UserResponse.java
@@ -1,15 +1,35 @@
 package com.example.backend.dto;
+import java.time.LocalDateTime;   
 
 public class UserResponse {
   private String id;
   private String username;
   private String email;
+  private String sports;
+  private String bio;
+  private String profileImage;
+  private LocalDateTime createdAt;
 
   public UserResponse(String id, String username, String email) {
     this.id = id; this.username = username; this.email = email;
   }
 
   public String getId() { return id; }
+  
   public String getUsername() { return username; }
   public String getEmail() { return email; }
+  public String getSports() { return sports; }
+  public String getBio() { return bio; }
+  public String getProfileImage() { return profileImage; }
+  public LocalDateTime getCreatedAt() { return createdAt; }
+
+
+  public void setId(String id) { this.id = id; }
+  public void setUsername(String username) { this.username = username; }
+  public void setEmail(String email) { this.email = email; }
+  public void setSports(String sports) { this.sports = sports; }
+  public void setBio(String bio) { this.bio = bio; }
+  public void setProfileImage(String profileImage) { this.profileImage = profileImage; }
+  public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
 }
+

--- a/backend/src/main/java/com/example/backend/model/User.java
+++ b/backend/src/main/java/com/example/backend/model/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDateTime;   
 import java.util.Collection;
 import java.util.Collections;
 
@@ -29,6 +30,23 @@ public class User implements UserDetails {
   @Column(nullable = false)
   private String password;
 
+  // Almacenar como texto para evitar problemas de tipo al registrar usuarios
+  @Column
+  private String sports; // JSON serializado como String
+
+  @Column(length = 500)
+  private String bio;
+
+  @Column(name = "profile_image")
+  private String profileImage;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+  }
   public User() {}
 
   public User(String username, String email, String password) {
@@ -41,11 +59,20 @@ public class User implements UserDetails {
   public String getUsername() { return username; }
   public String getEmail() { return email; }
   public String getPassword() { return password; }
+  public String getSports() { return sports; }
+  public String getBio() { return bio; }
+  public String getProfileImage() { return profileImage; }
+  public LocalDateTime getCreatedAt() { return createdAt; }
+
 
   public void setId(Long id) { this.id = id; }
   public void setUsername(String username) { this.username = username; }
   public void setEmail(String email) { this.email = email; }
   public void setPassword(String password) { this.password = password; }
+  public void setSports(String sports) { this.sports = sports; }
+  public void setBio(String bio) { this.bio = bio; }
+  public void setProfileImage(String profileImage) { this.profileImage = profileImage; }
+  public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
 
   // Métodos requeridos por UserDetails
   @Override

--- a/backend/src/main/java/com/example/backend/model/UserSport.java
+++ b/backend/src/main/java/com/example/backend/model/UserSport.java
@@ -1,0 +1,37 @@
+package com.example.backend.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "user_sports")
+public class UserSport {
+    public enum Level {
+        PRINCIPIANTE, INTERMEDIO, AVANZADO, EXPERTO
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String sport;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Level level;
+
+    // Getters y Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public String getSport() { return sport; }
+    public void setSport(String sport) { this.sport = sport; }
+    public Level getLevel() { return level; }
+    public void setLevel(Level level) { this.level = level; }
+}
+


### PR DESCRIPTION
FEATURES:
- Add SportsController with complete endpoints
  * GET /sports - Returns all sports and levels
  * GET /sports/levels - Returns only sport levels
  * GET /sports/available - Returns only available sports

- Add UserController
  * GET /users/{userId} - Returns user profile with sports data

- Add ConfigurarPerfilController
  * POST /profile/{userId} - Update user profile with sports, bio, image

- Add 10 sports in Catalan:
  futbol, basquet, tenis, natacio, ciclisme, correr, gimnasia, senderisme, padel, surf

- Add 4 sport levels:
  PRINCIPIANTE, INTERMEDIO, AVANZADO, EXPERTO

SECURITY:
- Update SecurityConfig to allow public access to:
  * /auth/** (register, login)
  * /sports/** (sports endpoints)
  * /users/** (user profiles)
  * /profile/** (profile updates)

TESTED ENDPOINTS:

1. GET /sports
   - Status: 200
   - Returns 10 sports + 4 levels

2. GET /users/{userId}
   - Status: 200
   - Returns user data (null fields before profile update)

3. POST /profile/{userId}
   - Status: 200
   - Saves sports array with levels, bio, profileImage

4. GET /users/{userId} (after profile update)
   - Status: 200
   - Returns complete user profile with sports data

5. POST /auth/login
   - Status: 200
   - Returns user data

6. GET /sports/levels
   - Status: 200
   - Returns 4 levels: PRINCIPIANTE, INTERMEDIO, AVANZADO, EXPERTO

7. GET /sports/available
   - Status: 200
   - Returns 10 sports in Catalan