### PR TITLE
feat(backend): make sports optional in profile update endpoint

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/ConfigurarPerfilController.java
+++ b/backend/src/main/java/com/example/backend/controller/ConfigurarPerfilController.java
@@ -12,54 +12,86 @@ import java.util.Map;
 @RestController
 @RequestMapping("/profile")
 public class ConfigurarPerfilController {
-    
+
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
-    
+
     public ConfigurarPerfilController(UserRepository userRepository, ObjectMapper objectMapper) {
         this.userRepository = userRepository;
         this.objectMapper = objectMapper;
     }
-    
+
     @PostMapping("/{userId}")
     public ResponseEntity<?> configurarPerfil(
             @PathVariable Long userId,
             @RequestBody Map<String, Object> body) {
         
         try {
-            // Validar que sports existe y no está vacío
-            List<?> sportsList = (List<?>) body.get("sports");
-            if (sportsList == null || sportsList.isEmpty()) {
-                return ResponseEntity.badRequest().body(Map.of(
-                    "message", "Validation failed",
-                    "errors", Map.of("sports", "Select at least one sport")
-                ));
-            }
-            
-            return userRepository.findById(userId)
-                .map(user -> {
-                    try {
-                        String sportsJson = objectMapper.writeValueAsString(sportsList);
-                        user.setSports(sportsJson);
+            // Validar sports SOLO si está presente en el body
+            if (body.containsKey("sports")) {
+                List<?> sportsList = (List<?>) body.get("sports");
+                
+                // Si sports está presente pero es un array vacío, devolver error
+                if (sportsList == null || sportsList.isEmpty()) {
+                    return ResponseEntity.badRequest().body(Map.of(
+                        "message", "Validation failed",
+                        "errors", Map.of("sports", "Select at least one sport")
+                    ));
+                }
+                
+                // Si sports tiene elementos, validarlo y guardarlo
+                return userRepository.findById(userId)
+                    .map(user -> {
+                        try {
+                            String sportsJson = objectMapper.writeValueAsString(sportsList);
+                            user.setSports(sportsJson);
+                            
+                            // Actualizar bio y profileImage si están presentes
+                            if (body.containsKey("bio")) {
+                                user.setBio((String) body.get("bio"));
+                            }
+                            if (body.containsKey("profileImage")) {
+                                user.setProfileImage((String) body.get("profileImage"));
+                            }
+                            
+                            userRepository.save(user);
+                            return ResponseEntity.ok(Map.of("message", "Profile saved"));
+                        } catch (Exception e) {
+                            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                .body(Map.of("message", "Error saving profile"));
+                        }
+                    })
+                    .orElse(ResponseEntity.notFound().build());
+            } else {
+                // Si sports NO está en el body, solo actualizar bio/profileImage
+                return userRepository.findById(userId)
+                    .map(user -> {
+                        boolean updated = false;
                         
                         if (body.containsKey("bio")) {
                             user.setBio((String) body.get("bio"));
+                            updated = true;
                         }
                         if (body.containsKey("profileImage")) {
                             user.setProfileImage((String) body.get("profileImage"));
+                            updated = true;
                         }
                         
-                        userRepository.save(user);
-                        return ResponseEntity.ok(Map.of("message", "Profile saved"));
-                    } catch (Exception e) {
-                        return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
-                    }
-                })
-                .orElse(ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(Map.of("error", "User not found")));
-                    
+                        if (updated) {
+                            userRepository.save(user);
+                            return ResponseEntity.ok(Map.of("message", "Profile saved"));
+                        } else {
+                            return ResponseEntity.badRequest().body(Map.of(
+                                "message", "No fields to update"
+                            ));
+                        }
+                    })
+                    .orElse(ResponseEntity.notFound().build());
+            }
+            
         } catch (Exception e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("message", "Error processing request"));
         }
     }
 }


### PR DESCRIPTION
- Modified ConfigurarPerfilController to allow updating bio and profileImage independently
- Sports field is now optional in POST /profile/{userId}
- If sports is present and empty, validation error is returned (400)
- If sports is not present, existing sports in DB are preserved
- Tested all scenarios: bio only, image only, bio+image, sports+bio+image, empty sports validation

Tested endpoints:
- POST /profile/{userId} with only bio: 200 OK
- POST /profile/{userId} with only profileImage: 200 OK
- POST /profile/{userId} with bio + profileImage: 200 OK
- POST /profile/{userId} with sports + bio + profileImage: 200 OK
- POST /profile/{userId} with empty sports array: 400 Bad Request
- GET /users/{userId}: 200 OK (sports preserved)"