### PR TITLE
Fix: Remove incorrect User-ID header to restore session-based authentication

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -6,12 +6,12 @@ console.log('[API] API_BASE =', API_BASE);
 
 async function request(path, { method = 'GET', body, headers = {}, credentials = 'include' } = {}) {
   const url = API_BASE + path
-  console.log(`[API] ${method} ->`, url); 
+  console.log(`[API] ${method} ->`, url);
 
-  const userId = localStorage.getItem('userId');
-  if (userId && !path.startsWith('/auth/')) {
-    headers['User-ID'] = userId; // Añadimos la cabecera que espera el backend
-  }
+  //const userId = localStorage.getItem('userId');
+  //if (userId && !path.startsWith('/auth/')) {
+    //headers['User-ID'] = userId; // Añadimos la cabecera que espera el backend
+  //}
 
   const opts = {
     method,


### PR DESCRIPTION
This PR removes the manually added User-ID header from the frontend API client.
That header is not used by the backend and was interfering with Spring Security's session-based authentication, causing authenticated requests (such as event creation) to fail with 403 Forbidden in develop and preproduction environments.

What was happening:

- The frontend added User-ID to every request except /auth/.
- The backend does not authenticate using this header, only using the session (JSESSIONID).
- This unexpected header caused Spring Security to treat the request as unauthenticated.

 As a result, endpoints like POST /events failed with 403 despite a valid login.

Changes made:

- Remove logic that reads userId from localStorage.
- Remove the injection of the custom User-ID header.
- Allow session cookies to be the only authentication mechanism (as expected by Spring Security).
