### PR TITLE
Fix session cookie for cross-site authentication (SameSite=None)

### DIFF
--- a/backend/src/main/java/com/example/backend/config/CookieConfig.java
+++ b/backend/src/main/java/com/example/backend/config/CookieConfig.java
@@ -1,0 +1,15 @@
+package com.example.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.web.server.Cookie.SameSite;
+import org.springframework.boot.web.servlet.server.CookieSameSiteSupplier;
+
+@Configuration
+public class CookieConfig {
+
+    @Bean
+    public CookieSameSiteSupplier applicationCookieSameSiteSupplier() {
+        return CookieSameSiteSupplier.ofNone().whenHasName("JSESSIONID");
+    }
+}


### PR DESCRIPTION
This PR fixes the 403 Forbidden errors when creating events from Netlify by ensuring the session cookie (JSESSIONID) is accepted in cross-site requests.

Browsers block cookies without SameSite=None on cross-domain requests (Netlify → Render).
The backend was sending SameSite=Lax, causing the session to be rejected and POST requests to fail.

Changes made:

- Added CookieConfig to force JSESSIONID cookies to use:
- SameSite=None

