### PR TITLE
Use correct backend base URL for profile image uploads

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/ConfigurarPerfilController.java
+++ b/backend/src/main/java/com/example/backend/controller/ConfigurarPerfilController.java
@@ -5,13 +5,13 @@ import com.example.backend.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;   
+import org.springframework.web.multipart.MultipartFile;
 
-import java.nio.file.*;                                    
-import java.io.IOException;                                
+import java.nio.file.*;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;                                     
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/profile")
@@ -29,12 +29,12 @@ public class ConfigurarPerfilController {
     public ResponseEntity<?> configurarPerfil(
             @PathVariable Long userId,
             @RequestBody Map<String, Object> body) {
-        
+
         try {
             // Validar sports SOLO si está presente en el body
             if (body.containsKey("sports")) {
                 List<?> sportsList = (List<?>) body.get("sports");
-                
+
                 // Si sports está presente pero es un array vacío, devolver error
                 if (sportsList == null || sportsList.isEmpty()) {
                     return ResponseEntity.badRequest().body(Map.of(
@@ -42,14 +42,14 @@ public class ConfigurarPerfilController {
                         "errors", Map.of("sports", "Select at least one sport")
                     ));
                 }
-                
+
                 // Si sports tiene elementos, validarlo y guardarlo
                 return userRepository.findById(userId)
                     .map(user -> {
                         try {
                             String sportsJson = objectMapper.writeValueAsString(sportsList);
                             user.setSports(sportsJson);
-                            
+
                             // Actualizar bio y profileImage si están presentes
                             if (body.containsKey("bio")) {
                                 user.setBio((String) body.get("bio"));
@@ -57,7 +57,7 @@ public class ConfigurarPerfilController {
                             if (body.containsKey("profileImage")) {
                                 user.setProfileImage((String) body.get("profileImage"));
                             }
-                            
+
                             userRepository.save(user);
                             return ResponseEntity.ok(Map.of("message", "Profile saved"));
                         } catch (Exception e) {
@@ -71,7 +71,7 @@ public class ConfigurarPerfilController {
                 return userRepository.findById(userId)
                     .map(user -> {
                         boolean updated = false;
-                        
+
                         if (body.containsKey("bio")) {
                             user.setBio((String) body.get("bio"));
                             updated = true;
@@ -80,7 +80,7 @@ public class ConfigurarPerfilController {
                             user.setProfileImage((String) body.get("profileImage"));
                             updated = true;
                         }
-                        
+
                         if (updated) {
                             userRepository.save(user);
                             return ResponseEntity.ok(Map.of("message", "Profile saved"));
@@ -92,42 +92,48 @@ public class ConfigurarPerfilController {
                     })
                     .orElse(ResponseEntity.notFound().build());
             }
-            
+
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(Map.of("message", "Error processing request"));
         }
     }
 
-         
-    
+
+
         @PostMapping("/{userId}/avatar")
         public ResponseEntity<?> uploadAvatar(
-                @PathVariable Long userId, 
+                @PathVariable Long userId,
                 @RequestParam("avatar") MultipartFile file) {
-            
+
             if (file.isEmpty()) {
                 return ResponseEntity.badRequest().body(Map.of("message", "File is empty"));
             }
-    
+
             try {
                 User user = userRepository.findById(userId)
                     .orElseThrow(() -> new RuntimeException("User not found"));
-    
+
                 String uploadDir = "uploads/avatars/";
                 Files.createDirectories(Paths.get(uploadDir));
-    
+
                 String filename = userId + "_" + UUID.randomUUID() + "_" + file.getOriginalFilename();
                 Path filePath = Paths.get(uploadDir + filename);
                 Files.copy(file.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
-    
-                String fileUrl = "http://localhost:8080/uploads/avatars/" + filename;
-    
+
+                // 🚀 Obtener automáticamente el dominio real donde está corriendo el backend
+                String backendUrl = System.getenv("RENDER_EXTERNAL_URL");
+                if (backendUrl == null || backendUrl.isBlank()) {
+                    backendUrl = "http://localhost:8080"; // fallback para desarrollo local
+                }
+
+                String fileUrl = backendUrl + "/uploads/avatars/" + filename;
+
                 user.setProfileImage(fileUrl);
                 userRepository.save(user);
-    
+
                 return ResponseEntity.ok(Map.of("profileImage", fileUrl));
-    
+
             } catch (IOException e) {
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("message", "Error uploading file"));
@@ -135,5 +141,6 @@ public class ConfigurarPerfilController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(Map.of("message", e.getMessage()));
             }
-        }  
-    }   
+        }
+
+    }


### PR DESCRIPTION
Esta PR corrige un problema en el que las imágenes de perfil se guardaban con la URL http://localhost:8080/..., lo que producía errores en producción al cargar avatares.

Cambios principales:
- Reemplazado el hardcode de localhost por un sistema dinámico usando RENDER_EXTERNAL_URL.
- Ahora se genera correctamente la URL completa del archivo en producción y local.
- Mejora la compatibilidad con Render y evita ERR_CONNECTION_REFUSED.