### PR TITLE
TEST:  add service unit tests, frontend , backend 

### DIFF
--- a/backend/src/test/java/com/example/backend/controller/ChatControllerWebMvcTest.java
+++ b/backend/src/test/java/com/example/backend/controller/ChatControllerWebMvcTest.java
@@ -1,0 +1,119 @@
+package com.example.backend.controller;
+
+import com.example.backend.model.Event;
+import com.example.backend.model.User;
+import com.example.backend.repository.ChatMessageRepository;
+import com.example.backend.repository.EventRepository;
+import com.example.backend.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ChatController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ChatControllerWebMvcTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @MockBean
+  ChatMessageRepository chatRepo;
+
+  @MockBean
+  EventRepository eventRepo;
+
+  @MockBean
+  AuthService authService;
+
+  @Test
+  void getMessages_returns404_whenEventDoesNotExist() throws Exception {
+    when(eventRepo.existsById(1L)).thenReturn(false);
+
+    mvc.perform(get("/events/1/chat/messages"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("Event not found"));
+  }
+
+  @Test
+  void sendMessage_returns400_whenTextEmpty() throws Exception {
+    mvc.perform(post("/events/1/chat/messages")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"text\":\"\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errors.text").value("Message cannot be empty"));
+  }
+
+  @Test
+  void sendMessage_returns401_whenAuthenticationRequired() throws Exception {
+    when(authService.getCurrentAuthenticatedUser()).thenThrow(new org.springframework.security.core.userdetails.UsernameNotFoundException("no"));
+
+    mvc.perform(post("/events/1/chat/messages")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"text\":\"hello\"}"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("Authentication required"));
+  }
+
+  @Test
+  void sendMessage_returns404_whenEventMissing() throws Exception {
+    User user = new User("alice", "a@b.com", "p");
+    user.setId(1L);
+    when(authService.getCurrentAuthenticatedUser()).thenReturn(user);
+    when(eventRepo.findById(1L)).thenReturn(Optional.empty());
+
+    mvc.perform(post("/events/1/chat/messages")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"text\":\"hello\"}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("Event not found"));
+  }
+
+  @Test
+  void sendMessage_returns403_whenUserNotParticipant() throws Exception {
+    User user = new User("alice", "a@b.com", "p");
+    user.setId(1L);
+    when(authService.getCurrentAuthenticatedUser()).thenReturn(user);
+
+    Event event = new Event();
+    event.setId(1L);
+    event.setTitle("Test");
+    event.setSport("Tennis");
+    event.setLocation("Court");
+    event.setDate(LocalDate.now().plusDays(1));
+    event.setTime(LocalTime.of(10, 0));
+    event.setOrganizer("org");
+    event.setCapacity(10);
+    event.setPrice(BigDecimal.ZERO);
+
+    when(eventRepo.findById(1L)).thenReturn(Optional.of(event));
+
+    mvc.perform(post("/events/1/chat/messages")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"text\":\"hello\"}"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("Not a participant"));
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/controller/ConfigurarPerfilControllerTest.java
+++ b/backend/src/test/java/com/example/backend/controller/ConfigurarPerfilControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.util.Map;
 import java.util.Optional;
@@ -18,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -78,5 +80,80 @@ class ConfigurarPerfilControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .content(json))
       .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void whenNoSports_andBioPresent_shouldSaveAndReturn200() throws Exception {
+    User u = new User();
+    u.setId(1L);
+    when(userRepository.findById(1L)).thenReturn(Optional.of(u));
+
+    var body = Map.of("bio", "updated");
+    String json = mapper.writeValueAsString(body);
+
+    mvc.perform(post("/profile/1")
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.message").value("Profile saved"));
+
+    verify(userRepository).save(any(User.class));
+  }
+
+  @Test
+  void whenNoFieldsProvided_shouldReturn400() throws Exception {
+    User u = new User();
+    u.setId(1L);
+    when(userRepository.findById(1L)).thenReturn(Optional.of(u));
+
+    String json = mapper.writeValueAsString(Map.of());
+
+    mvc.perform(post("/profile/1")
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("No fields to update"));
+  }
+
+  @Test
+  void uploadAvatar_shouldReturn400_whenFileEmpty() throws Exception {
+    MockMultipartFile file = new MockMultipartFile("avatar", "avatar.png", "image/png", new byte[0]);
+
+    mvc.perform(multipart("/profile/1/avatar")
+        .file(file)
+        .with(csrf()))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("File is empty"));
+  }
+
+  @Test
+  void uploadAvatar_shouldReturn404_whenUserNotFound() throws Exception {
+    when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+    MockMultipartFile file = new MockMultipartFile("avatar", "avatar.png", "image/png", "x".getBytes());
+
+    mvc.perform(multipart("/profile/1/avatar")
+        .file(file)
+        .with(csrf()))
+      .andExpect(status().isNotFound())
+      .andExpect(jsonPath("$.message").value("User not found"));
+  }
+
+  @Test
+  void uploadAvatar_shouldReturn200_whenUploadOk() throws Exception {
+    User u = new User();
+    u.setId(1L);
+    when(userRepository.findById(1L)).thenReturn(Optional.of(u));
+    when(userRepository.save(any(User.class))).thenReturn(u);
+
+    MockMultipartFile file = new MockMultipartFile("avatar", "avatar.png", "image/png", "hello".getBytes());
+
+    mvc.perform(multipart("/profile/1/avatar")
+        .file(file)
+        .with(csrf()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.profileImage").value(org.hamcrest.Matchers.containsString("/uploads/avatars/")));
   }
 }

--- a/backend/src/test/java/com/example/backend/controller/EventParticipantsControllerTest.java
+++ b/backend/src/test/java/com/example/backend/controller/EventParticipantsControllerTest.java
@@ -1,0 +1,125 @@
+package com.example.backend.controller;
+
+import com.example.backend.model.Event;
+import com.example.backend.model.User;
+import com.example.backend.repository.EventRepository;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(EventParticipantsController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class EventParticipantsControllerTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @MockBean
+  EventRepository eventRepository;
+
+  @Test
+  void listParticipants_returns200_withCountAndCapacity() throws Exception {
+    Event event = new Event();
+    event.setId(10L);
+    event.setTitle("Test");
+    event.setSport("Tennis");
+    event.setLocation("Court");
+    event.setDate(LocalDate.now().plusDays(1));
+    event.setTime(LocalTime.of(10, 0));
+    event.setOrganizer("organizer");
+    event.setCapacity(5);
+    event.setPrice(BigDecimal.ZERO);
+
+    User u1 = new User("alice", "a@b.com", "p");
+    u1.setId(1L);
+    u1.setProfileImage("img1");
+    User u2 = new User("bob", "b@b.com", "p");
+    u2.setId(2L);
+    u2.setProfileImage("img2");
+    event.addParticipant(u1);
+    event.addParticipant(u2);
+
+    when(eventRepository.findById(10L)).thenReturn(Optional.of(event));
+
+    mvc.perform(get("/events/10/participants"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.count").value(2))
+        .andExpect(jsonPath("$.capacity").value(5))
+        .andExpect(jsonPath("$.participants[*].id", Matchers.containsInAnyOrder(1, 2)));
+  }
+
+  @Test
+  void listParticipants_returns404_whenEventMissing() throws Exception {
+    when(eventRepository.findById(999L)).thenReturn(Optional.empty());
+
+    mvc.perform(get("/events/999/participants"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("Event not found"));
+  }
+
+  @Test
+  void isParticipant_returnsTrue_whenUserIsParticipant() throws Exception {
+    Event event = new Event();
+    event.setId(10L);
+    event.setTitle("Test");
+    event.setSport("Tennis");
+    event.setLocation("Court");
+    event.setDate(LocalDate.now().plusDays(1));
+    event.setTime(LocalTime.of(10, 0));
+    event.setOrganizer("organizer");
+    event.setCapacity(5);
+    event.setPrice(BigDecimal.ZERO);
+
+    User u1 = new User("alice", "a@b.com", "p");
+    u1.setId(1L);
+    event.addParticipant(u1);
+
+    when(eventRepository.findById(10L)).thenReturn(Optional.of(event));
+
+    mvc.perform(get("/events/10/participants/1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isParticipant").value(true))
+        .andExpect(jsonPath("$.capacity").value(5))
+        .andExpect(jsonPath("$.participants").value(1));
+  }
+
+  @Test
+  void isParticipant_returnsFalse_whenUserIsNotParticipant() throws Exception {
+    Event event = new Event();
+    event.setId(10L);
+    event.setTitle("Test");
+    event.setSport("Tennis");
+    event.setLocation("Court");
+    event.setDate(LocalDate.now().plusDays(1));
+    event.setTime(LocalTime.of(10, 0));
+    event.setOrganizer("organizer");
+    event.setCapacity(5);
+    event.setPrice(BigDecimal.ZERO);
+
+    User u1 = new User("alice", "a@b.com", "p");
+    u1.setId(1L);
+    event.addParticipant(u1);
+
+    when(eventRepository.findById(10L)).thenReturn(Optional.of(event));
+
+    mvc.perform(get("/events/10/participants/999"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isParticipant").value(false))
+        .andExpect(jsonPath("$.capacity").value(5))
+        .andExpect(jsonPath("$.participants").value(1));
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/controller/EventsControllerTest.java
+++ b/backend/src/test/java/com/example/backend/controller/EventsControllerTest.java
@@ -18,12 +18,16 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -125,5 +129,63 @@ class EventsControllerTest {
       .andExpect(status().isCreated())
       .andExpect(jsonPath("$.id").value(123))
       .andExpect(jsonPath("$.message").value("Event created"));
+  }
+
+  @Test
+  void list_returns200_andDelegatesToService() throws Exception {
+    when(service.search(any(), any(), any(), any(), any(), any()))
+        .thenReturn(List.of(Map.of("id", "1", "title", "Test")));
+
+    mvc.perform(get("/events?q=test"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value("1"));
+  }
+
+  @Test
+  void detail_returns404_whenEventNotFound() throws Exception {
+    when(service.detail(999L)).thenThrow(new NoSuchElementException("Event not found"));
+
+    mvc.perform(get("/events/999"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("Event not found"));
+  }
+
+  @Test
+  void join_returns400_whenEventFull() throws Exception {
+    User mockUser = new User();
+    mockUser.setId(1L);
+    when(authService.getCurrentAuthenticatedUser()).thenReturn(mockUser);
+
+    doThrow(new EventService.EventFullException()).when(service).join(1L, 1L);
+
+    mvc.perform(post("/events/1/join").with(csrf()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("Event full"));
+  }
+
+  @Test
+  void join_returns401_whenNotAuthenticated() throws Exception {
+    when(authService.getCurrentAuthenticatedUser())
+        .thenThrow(new org.springframework.security.core.userdetails.UsernameNotFoundException("no auth"));
+
+    mvc.perform(post("/events/1/join").with(csrf()))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("Authentication required"));
+  }
+
+  @Test
+  void create_returns400_whenValidationException() throws Exception {
+    when(service.create(any(Event.class), any()))
+        .thenThrow(new EventService.ValidationException(Map.of("title", "Title is required")));
+
+    String json = mapper.writeValueAsString(new Event());
+
+    mvc.perform(post("/events")
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("Validation failed"))
+      .andExpect(jsonPath("$.errors.title").value("Title is required"));
   }
 }

--- a/backend/src/test/java/com/example/backend/controller/SportsControllerTest.java
+++ b/backend/src/test/java/com/example/backend/controller/SportsControllerTest.java
@@ -1,0 +1,45 @@
+package com.example.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SportsController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SportsControllerTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @Test
+  void getSports_returnsSportsAndLevels() throws Exception {
+    mvc.perform(get("/sports"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sports").isArray())
+        .andExpect(jsonPath("$.levels").isArray())
+        .andExpect(jsonPath("$.total_sports").value(10))
+        .andExpect(jsonPath("$.total_levels").value(4));
+  }
+
+  @Test
+  void getSportLevels_returnsLevelsOnly() throws Exception {
+    mvc.perform(get("/sports/levels"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.levels").isArray())
+        .andExpect(jsonPath("$.levels.length()").value(4));
+  }
+
+  @Test
+  void getAvailableSports_returnsSportsOnly() throws Exception {
+    mvc.perform(get("/sports/available"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sports").isArray())
+        .andExpect(jsonPath("$.sports.length()").value(10));
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/example/backend/controller/UserControllerTest.java
@@ -1,0 +1,57 @@
+package com.example.backend.controller;
+
+import com.example.backend.model.User;
+import com.example.backend.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @MockBean
+  UserRepository userRepository;
+
+  @Test
+  void getUserById_returns200_whenFound() throws Exception {
+    User user = new User("alice", "a@b.com", "p");
+    user.setId(1L);
+    user.setSports("[{\"sport\":\"tenis\",\"level\":\"INTERMEDIO\"}]");
+    user.setBio("bio");
+    user.setProfileImage("img");
+    user.setCreatedAt(LocalDateTime.parse("2025-01-01T00:00:00"));
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+    mvc.perform(get("/users/1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.username").value("alice"))
+        .andExpect(jsonPath("$.email").value("a@b.com"))
+        .andExpect(jsonPath("$.sports").exists())
+        .andExpect(jsonPath("$.profileImage").value("img"));
+  }
+
+  @Test
+  void getUserById_returns404_whenMissing() throws Exception {
+    when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+    mvc.perform(get("/users/999"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("User not found"));
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/example/backend/service/AuthServiceTest.java
@@ -1,0 +1,230 @@
+package com.example.backend.service;
+
+import com.example.backend.dto.LoginRequest;
+import com.example.backend.dto.RegisterRequest;
+import com.example.backend.dto.UserResponse;
+import com.example.backend.model.User;
+import com.example.backend.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+  @Mock
+  UserRepository userRepository;
+
+  @Mock
+  PasswordEncoder passwordEncoder;
+
+  @Mock
+  AuthenticationManager authenticationManager;
+
+  @InjectMocks
+  AuthService authService;
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void register_throwsValidationException_whenUsernameAlreadyTaken() {
+    RegisterRequest req = new RegisterRequest();
+    req.setUsername("taken");
+    req.setEmail("a@b.com");
+    req.setPassword("password123");
+
+    when(userRepository.existsByUsername("taken")).thenReturn(true);
+
+    AuthService.ValidationException ex = assertThrows(AuthService.ValidationException.class, () -> authService.register(req));
+    assertEquals("Validation failed", ex.getMessage());
+    assertEquals("Username already taken", ex.fieldErrors.get("username"));
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void register_throwsValidationException_whenEmailAlreadyTaken() {
+    RegisterRequest req = new RegisterRequest();
+    req.setUsername("newuser");
+    req.setEmail("taken@b.com");
+    req.setPassword("password123");
+
+    when(userRepository.existsByUsername("newuser")).thenReturn(false);
+    when(userRepository.existsByEmail("taken@b.com")).thenReturn(true);
+
+    AuthService.ValidationException ex = assertThrows(AuthService.ValidationException.class, () -> authService.register(req));
+    assertEquals("Email already taken", ex.fieldErrors.get("email"));
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void register_savesUser_andReturnsUserResponse_whenValid() {
+    RegisterRequest req = new RegisterRequest();
+    req.setUsername("newuser");
+    req.setEmail("new@b.com");
+    req.setPassword("password123");
+
+    when(userRepository.existsByUsername("newuser")).thenReturn(false);
+    when(userRepository.existsByEmail("new@b.com")).thenReturn(false);
+    when(passwordEncoder.encode("password123")).thenReturn("encoded");
+
+    User saved = new User("newuser", "new@b.com", "encoded");
+    saved.setId(10L);
+    when(userRepository.save(any(User.class))).thenReturn(saved);
+
+    UserResponse resp = authService.register(req);
+
+    assertEquals("10", resp.getId());
+    assertEquals("newuser", resp.getUsername());
+    assertEquals("new@b.com", resp.getEmail());
+    verify(userRepository).save(any(User.class));
+  }
+
+  @Test
+  void login_setsSecurityContext_andReturnsUserResponse_whenAuthenticationSucceeds() {
+    LoginRequest req = new LoginRequest();
+    req.setUsername("alice");
+    req.setPassword("password123");
+
+    User principal = new User("alice", "alice@b.com", "encoded");
+    principal.setId(1L);
+
+    Authentication auth = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+    when(authenticationManager.authenticate(any())).thenReturn(auth);
+
+    UserResponse resp = authService.login(req);
+
+    assertEquals("1", resp.getId());
+    assertEquals("alice", resp.getUsername());
+    assertEquals("alice@b.com", resp.getEmail());
+    assertSame(auth, SecurityContextHolder.getContext().getAuthentication());
+  }
+
+  @Test
+  void login_throwsValidationException_whenBadCredentials() {
+    LoginRequest req = new LoginRequest();
+    req.setUsername("alice");
+    req.setPassword("wrong");
+
+    when(authenticationManager.authenticate(any())).thenThrow(new BadCredentialsException("Bad credentials"));
+
+    AuthService.ValidationException ex = assertThrows(AuthService.ValidationException.class, () -> authService.login(req));
+    assertEquals("Invalid password", ex.fieldErrors.get("password"));
+  }
+
+  @Test
+  void login_throwsValidationException_whenUsernameNotFound() {
+    LoginRequest req = new LoginRequest();
+    req.setUsername("missing");
+    req.setPassword("password123");
+
+    when(authenticationManager.authenticate(any())).thenThrow(new UsernameNotFoundException("User not found"));
+
+    AuthService.ValidationException ex = assertThrows(AuthService.ValidationException.class, () -> authService.login(req));
+    assertEquals("User not found", ex.fieldErrors.get("username"));
+  }
+
+  @Test
+  void login_throwsValidationException_whenOtherAuthenticationError() {
+    LoginRequest req = new LoginRequest();
+    req.setUsername("alice");
+    req.setPassword("password123");
+
+    when(authenticationManager.authenticate(any())).thenThrow(new AuthenticationServiceException("boom"));
+
+    AuthService.ValidationException ex = assertThrows(AuthService.ValidationException.class, () -> authService.login(req));
+    assertEquals("Invalid credentials", ex.fieldErrors.get("general"));
+  }
+
+  @Test
+  void getUserByUsername_throwsRuntimeException_whenNotFound() {
+    when(userRepository.findByUsername("missing")).thenReturn(Optional.empty());
+
+    RuntimeException ex = assertThrows(RuntimeException.class, () -> authService.getUserByUsername("missing"));
+    assertTrue(ex.getMessage().contains("User not found"));
+  }
+
+  @Test
+  void getCurrentAuthenticatedUser_throws_whenNoAuthentication() {
+    SecurityContextHolder.clearContext();
+    assertThrows(UsernameNotFoundException.class, () -> authService.getCurrentAuthenticatedUser());
+  }
+
+  @Test
+  void getCurrentAuthenticatedUser_throws_whenAnonymousUser() {
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    when(authentication.getPrincipal()).thenReturn("anonymousUser");
+
+    SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+    ctx.setAuthentication(authentication);
+    SecurityContextHolder.setContext(ctx);
+
+    assertThrows(UsernameNotFoundException.class, () -> authService.getCurrentAuthenticatedUser());
+  }
+
+  @Test
+  void getCurrentAuthenticatedUser_returnsPrincipal_whenPrincipalIsUser() {
+    User principal = new User("u", "u@b.com", "p");
+    principal.setId(99L);
+
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    when(authentication.getPrincipal()).thenReturn(principal);
+
+    SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+    ctx.setAuthentication(authentication);
+    SecurityContextHolder.setContext(ctx);
+
+    User result = authService.getCurrentAuthenticatedUser();
+    assertSame(principal, result);
+    verifyNoInteractions(userRepository);
+  }
+
+  @Test
+  void getCurrentAuthenticatedUser_loadsFromRepository_whenPrincipalIsUserDetails() {
+    UserDetails principal = org.springframework.security.core.userdetails.User
+        .withUsername("alice")
+        .password("x")
+        .authorities("ROLE_USER")
+        .build();
+
+    User repoUser = new User("alice", "alice@b.com", "p");
+    repoUser.setId(1L);
+    when(userRepository.findByUsername("alice")).thenReturn(Optional.of(repoUser));
+
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    when(authentication.getPrincipal()).thenReturn(principal);
+
+    SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+    ctx.setAuthentication(authentication);
+    SecurityContextHolder.setContext(ctx);
+
+    User result = authService.getCurrentAuthenticatedUser();
+    assertSame(repoUser, result);
+    verify(userRepository).findByUsername("alice");
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/service/DirectMessageServiceTest.java
+++ b/backend/src/test/java/com/example/backend/service/DirectMessageServiceTest.java
@@ -1,0 +1,104 @@
+package com.example.backend.service;
+
+import com.example.backend.model.DirectMessage;
+import com.example.backend.model.User;
+import com.example.backend.repository.DirectMessageRepository;
+import com.example.backend.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DirectMessageServiceTest {
+
+  @Mock
+  DirectMessageRepository repo;
+
+  @Mock
+  UserRepository userRepo;
+
+  @InjectMocks
+  DirectMessageService service;
+
+  @Test
+  void getAllMessagesOfUser_delegatesToRepository() {
+    when(repo.findBySenderIdOrReceiverIdOrderByTimestampDesc(1L, 1L)).thenReturn(List.of());
+
+    service.getAllMessagesOfUser(1L);
+
+    verify(repo).findBySenderIdOrReceiverIdOrderByTimestampDesc(1L, 1L);
+  }
+
+  @Test
+  void sendMessage_throws_whenSenderNotFound() {
+    when(userRepo.findById(1L)).thenReturn(Optional.empty());
+
+    NoSuchElementException ex = assertThrows(NoSuchElementException.class, () -> service.sendMessage(1L, 2L, "hi"));
+    assertEquals("User not found", ex.getMessage());
+    verify(repo, never()).save(any());
+  }
+
+  @Test
+  void sendMessage_savesMessageWithExpectedFields() {
+    User sender = new User("sender", "s@b.com", "p");
+    sender.setId(1L);
+    User receiver = new User("receiver", "r@b.com", "p");
+    receiver.setId(2L);
+
+    when(userRepo.findById(1L)).thenReturn(Optional.of(sender));
+    when(userRepo.findById(2L)).thenReturn(Optional.of(receiver));
+    when(repo.save(any(DirectMessage.class))).thenAnswer(inv -> inv.getArgument(0, DirectMessage.class));
+
+    DirectMessage saved = service.sendMessage(1L, 2L, "Hello!");
+
+    assertEquals("Hello!", saved.getText());
+    assertSame(sender, saved.getSender());
+    assertSame(receiver, saved.getReceiver());
+    assertFalse(saved.isRead());
+    assertNotNull(saved.getTimestamp());
+
+    verify(repo).save(any(DirectMessage.class));
+  }
+
+  @Test
+  void markConversationRead_marksOnlyMessagesReceivedByViewer() {
+    User viewer = new User("viewer", "v@b.com", "p");
+    viewer.setId(1L);
+    User other = new User("other", "o@b.com", "p");
+    other.setId(2L);
+
+    DirectMessage receivedByViewer = new DirectMessage();
+    receivedByViewer.setSender(other);
+    receivedByViewer.setReceiver(viewer);
+    receivedByViewer.setRead(false);
+
+    DirectMessage sentByViewer = new DirectMessage();
+    sentByViewer.setSender(viewer);
+    sentByViewer.setReceiver(other);
+    sentByViewer.setRead(false);
+
+    when(repo.findBySenderIdAndReceiverIdOrReceiverIdAndSenderIdOrderByTimestampAsc(1L, 2L, 1L, 2L))
+        .thenReturn(List.of(receivedByViewer, sentByViewer));
+
+    service.markConversationRead(1L, 2L);
+
+    assertTrue(receivedByViewer.isRead());
+    assertFalse(sentByViewer.isRead());
+
+    ArgumentCaptor<List<DirectMessage>> captor = ArgumentCaptor.forClass(List.class);
+    verify(repo).saveAll(captor.capture());
+    assertEquals(2, captor.getValue().size());
+  }
+}

--- a/backend/src/test/java/com/example/backend/service/EventServiceTest.java
+++ b/backend/src/test/java/com/example/backend/service/EventServiceTest.java
@@ -1,0 +1,233 @@
+package com.example.backend.service;
+
+import com.example.backend.model.Event;
+import com.example.backend.model.User;
+import com.example.backend.repository.EventRepository;
+import com.example.backend.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+  @Mock
+  EventRepository repo;
+
+  @Mock
+  UserRepository userRepo;
+
+  @Mock
+  NotificationService notificationService;
+
+  @InjectMocks
+  EventService service;
+
+  @Test
+  void create_throwsValidationException_withAllDetectedErrors() {
+    Event e = new Event();
+    e.setTitle(" ");
+    e.setSport(null);
+    e.setDate(LocalDate.now().minusDays(1));
+    e.setTime(null);
+    e.setLocation("");
+    e.setOrganizer("");
+    e.setCapacity(1);
+    e.setPrice(new BigDecimal("-1.00"));
+
+    EventService.ValidationException ex = assertThrows(EventService.ValidationException.class, () -> service.create(e, null));
+    Map<String, String> errors = ex.getErrors();
+    assertTrue(errors.containsKey("title"));
+    assertTrue(errors.containsKey("sport"));
+    assertTrue(errors.containsKey("date"));
+    assertTrue(errors.containsKey("time"));
+    assertTrue(errors.containsKey("location"));
+    assertTrue(errors.containsKey("organizer"));
+    assertTrue(errors.containsKey("capacity"));
+    assertTrue(errors.containsKey("price"));
+    verify(repo, never()).save(any());
+  }
+
+  @Test
+  void create_savesEventOnce_andResetsParticipants_whenNoUser() throws Exception {
+    Event e = validEvent();
+    e.setParticipants(10);
+    e.setParticipantUsers(new HashSet<>(Set.of(new User("someone", "s@b.com", "p"))));
+
+    when(repo.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0, Event.class));
+
+    Event saved = service.create(e, null);
+
+    assertEquals(0, saved.getParticipants());
+    assertNotNull(saved.getParticipantUsers());
+    assertTrue(saved.getParticipantUsers().isEmpty());
+    verify(repo, times(1)).save(any(Event.class));
+  }
+
+  @Test
+  void create_overridesOrganizer_andAutoAddsCreator_whenUserProvided() throws Exception {
+    User user = new User("alice", "alice@b.com", "p");
+    user.setId(1L);
+    when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+
+    Event e = validEvent();
+    e.setOrganizer("will-be-overridden");
+    e.setParticipantUsers(null);
+
+    when(repo.save(any(Event.class))).thenAnswer(inv -> {
+      Event arg = inv.getArgument(0, Event.class);
+      if (arg.getId() == null) arg.setId(123L);
+      return arg;
+    });
+
+    Event saved = service.create(e, 1L);
+
+    assertEquals("alice", saved.getOrganizer());
+    assertEquals(1, saved.getParticipants());
+    assertTrue(saved.getParticipantUsers().contains(user));
+    verify(repo, times(2)).save(any(Event.class));
+  }
+
+  @Test
+  void join_throwsEventFullException_whenAtCapacity() {
+    User user = new User("u", "u@b.com", "p");
+    user.setId(1L);
+    when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+
+    Event e = validEvent();
+    e.setId(10L);
+    e.setCapacity(2);
+    e.setParticipants(2);
+    when(repo.findById(10L)).thenReturn(Optional.of(e));
+
+    assertThrows(EventService.EventFullException.class, () -> service.join(10L, 1L));
+    verify(repo, never()).save(any());
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void join_returnsEarly_whenAlreadyParticipant() {
+    User user = new User("u", "u@b.com", "p");
+    user.setId(1L);
+    when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+
+    Event e = validEvent();
+    e.setId(10L);
+    e.setCapacity(5);
+    e.addParticipant(user);
+    when(repo.findById(10L)).thenReturn(Optional.of(e));
+
+    service.join(10L, 1L);
+
+    verify(repo, never()).save(any());
+    verifyNoInteractions(notificationService);
+  }
+
+  @Test
+  void join_savesEvent_andNotifiesUser_andOrganizer() {
+    User user = new User("participant", "p@b.com", "p");
+    user.setId(1L);
+    when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+
+    User organizer = new User("organizer", "o@b.com", "p");
+    organizer.setId(2L);
+    when(userRepo.findByUsername("organizer")).thenReturn(Optional.of(organizer));
+
+    Event e = validEvent();
+    e.setId(10L);
+    e.setOrganizer("organizer");
+    e.setCapacity(10);
+    when(repo.findById(10L)).thenReturn(Optional.of(e));
+    when(repo.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0, Event.class));
+
+    service.join(10L, 1L);
+
+    verify(repo).save(any(Event.class));
+    verify(notificationService).notifyJoinedEvent(1L, 10L, e.getTitle());
+    verify(notificationService).notifyNewParticipant(2L, 10L, e.getTitle(), 1L);
+  }
+
+  @Test
+  void join_ignoresOrganizerLookupErrors() {
+    User user = new User("participant", "p@b.com", "p");
+    user.setId(1L);
+    when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+    when(userRepo.findByUsername(anyString())).thenThrow(new RuntimeException("boom"));
+
+    Event e = validEvent();
+    e.setId(10L);
+    e.setOrganizer("organizer");
+    when(repo.findById(10L)).thenReturn(Optional.of(e));
+    when(repo.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0, Event.class));
+
+    assertDoesNotThrow(() -> service.join(10L, 1L));
+    verify(notificationService).notifyJoinedEvent(1L, 10L, e.getTitle());
+  }
+
+  @Test
+  void leave_throwsIllegalState_whenNotParticipant() {
+    User user = new User("u", "u@b.com", "p");
+    user.setId(1L);
+    when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+
+    Event e = validEvent();
+    e.setId(10L);
+    when(repo.findById(10L)).thenReturn(Optional.of(e));
+
+    assertThrows(IllegalStateException.class, () -> service.leave(10L, 1L));
+    verify(repo, never()).save(any());
+  }
+
+  @Test
+  void leave_removesParticipant_andSaves() {
+    User user = new User("u", "u@b.com", "p");
+    user.setId(1L);
+    when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+
+    Event e = validEvent();
+    e.setId(10L);
+    e.addParticipant(user);
+    when(repo.findById(10L)).thenReturn(Optional.of(e));
+
+    service.leave(10L, 1L);
+
+    assertFalse(e.getParticipantUsers().contains(user));
+    assertEquals(0, e.getParticipants());
+    verify(repo).save(any(Event.class));
+  }
+
+  @Test
+  void detail_throwsNoSuchElement_whenEventMissing() {
+    when(repo.findById(999L)).thenReturn(Optional.empty());
+    assertThrows(NoSuchElementException.class, () -> service.detail(999L));
+  }
+
+  private static Event validEvent() {
+    Event e = new Event();
+    e.setTitle("Morning Run");
+    e.setSport("running");
+    e.setDate(LocalDate.now().plusDays(5));
+    e.setTime(LocalTime.of(8, 0));
+    e.setLocation("Park");
+    e.setOrganizer("organizer");
+    e.setCapacity(10);
+    e.setPrice(BigDecimal.ZERO);
+    return e;
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/example/backend/service/NotificationServiceTest.java
@@ -1,0 +1,149 @@
+package com.example.backend.service;
+
+import com.example.backend.dto.NotificationDTO;
+import com.example.backend.model.Notification;
+import com.example.backend.repository.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  @Mock
+  NotificationRepository repo;
+
+  @Mock
+  WebSocketNotificationService wsService;
+
+  @InjectMocks
+  NotificationService service;
+
+  @Test
+  void createNotification_saves_andNotifiesViaWebSocket() {
+    Notification saved = new Notification(1L, Notification.NotificationType.NEW_MESSAGE, "t", "m", null, null);
+    saved.setId(55L);
+    when(repo.save(any(Notification.class))).thenReturn(saved);
+
+    service.createNotification(1L, Notification.NotificationType.NEW_MESSAGE, "t", "m", null, null);
+
+    verify(repo).save(any(Notification.class));
+    verify(wsService).notifyUser(1L, saved);
+  }
+
+  @Test
+  void getNotifications_mapsEntitiesToDTOs() {
+    Notification n = new Notification(1L, Notification.NotificationType.NEW_MESSAGE, "Title", "Msg", 10L, 20L);
+    n.setId(1L);
+    n.setCreatedAt(Instant.parse("2025-01-01T00:00:00Z"));
+    when(repo.findByUserIdOrderByCreatedAtDesc(1L)).thenReturn(List.of(n));
+
+    List<NotificationDTO> dtos = service.getNotifications(1L);
+
+    assertEquals(1, dtos.size());
+    assertEquals("1", dtos.get(0).getId());
+    assertEquals("NEW_MESSAGE", dtos.get(0).getType());
+    assertEquals("10", dtos.get(0).getEventId());
+    assertEquals("20", dtos.get(0).getRelatedUserId());
+  }
+
+  @Test
+  void markAsRead_throws_whenNotificationMissing() {
+    when(repo.findById(1L)).thenReturn(Optional.empty());
+    assertThrows(NoSuchElementException.class, () -> service.markAsRead(1L, 1L));
+  }
+
+  @Test
+  void markAsRead_throwsIllegalAccess_whenUserDoesNotOwnNotification() {
+    Notification n = new Notification();
+    n.setId(1L);
+    n.setUserId(99L);
+    when(repo.findById(1L)).thenReturn(Optional.of(n));
+
+    assertThrows(IllegalAccessException.class, () -> service.markAsRead(1L, 1L));
+    verify(repo, never()).save(any());
+  }
+
+  @Test
+  void markAsRead_setsReadTrue_andSaves_whenAuthorized() throws Exception {
+    Notification n = new Notification();
+    n.setId(1L);
+    n.setUserId(1L);
+    n.setRead(false);
+    when(repo.findById(1L)).thenReturn(Optional.of(n));
+
+    service.markAsRead(1L, 1L);
+
+    assertTrue(n.getRead());
+    verify(repo).save(n);
+  }
+
+  @Test
+  void markAllAsRead_marksOnlyUnread_andReturnsCount() {
+    Notification unread1 = new Notification();
+    unread1.setId(1L);
+    unread1.setUserId(1L);
+    unread1.setRead(false);
+
+    Notification unread2 = new Notification();
+    unread2.setId(2L);
+    unread2.setUserId(1L);
+    unread2.setRead(false);
+
+    Notification alreadyRead = new Notification();
+    alreadyRead.setId(3L);
+    alreadyRead.setUserId(1L);
+    alreadyRead.setRead(true);
+
+    when(repo.findByUserIdOrderByCreatedAtDesc(1L)).thenReturn(List.of(unread1, alreadyRead, unread2));
+
+    long count = service.markAllAsRead(1L);
+
+    assertEquals(2L, count);
+    assertTrue(unread1.getRead());
+    assertTrue(unread2.getRead());
+    assertTrue(alreadyRead.getRead());
+
+    ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
+    verify(repo).saveAll(captor.capture());
+    assertEquals(2, captor.getValue().size());
+  }
+
+  @Test
+  void deleteNotification_deletes_whenAuthorized() throws Exception {
+    Notification n = new Notification();
+    n.setId(1L);
+    n.setUserId(1L);
+    when(repo.findById(1L)).thenReturn(Optional.of(n));
+
+    service.deleteNotification(1L, 1L);
+
+    verify(repo).delete(n);
+  }
+
+  @Test
+  void notifyNewMessage_createsNotification_andNotifiesWebSocket() {
+    when(repo.save(any(Notification.class))).thenAnswer(inv -> {
+      Notification n = inv.getArgument(0, Notification.class);
+      n.setId(123L);
+      return n;
+    });
+
+    service.notifyNewMessage(1L, "alice");
+
+    verify(wsService).notifyUser(eq(1L), any(Notification.class));
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/service/UserDetailsServiceImplTest.java
+++ b/backend/src/test/java/com/example/backend/service/UserDetailsServiceImplTest.java
@@ -1,0 +1,40 @@
+package com.example.backend.service;
+
+import com.example.backend.model.User;
+import com.example.backend.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserDetailsServiceImplTest {
+
+  @Mock
+  UserRepository userRepository;
+
+  @InjectMocks
+  UserDetailsServiceImpl service;
+
+  @Test
+  void loadUserByUsername_returnsUser_whenFound() {
+    User user = new User("alice", "a@b.com", "p");
+    when(userRepository.findByUsername("alice")).thenReturn(Optional.of(user));
+
+    assertSame(user, service.loadUserByUsername("alice"));
+  }
+
+  @Test
+  void loadUserByUsername_throws_whenMissing() {
+    when(userRepository.findByUsername("missing")).thenReturn(Optional.empty());
+    assertThrows(UsernameNotFoundException.class, () -> service.loadUserByUsername("missing"));
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/service/WebSocketNotificationServiceTest.java
+++ b/backend/src/test/java/com/example/backend/service/WebSocketNotificationServiceTest.java
@@ -1,0 +1,95 @@
+package com.example.backend.service;
+
+import com.example.backend.model.Notification;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class WebSocketNotificationServiceTest {
+
+  @Test
+  void notifyUser_doesNothing_whenNoSessionsRegistered() {
+    WebSocketNotificationService service = new WebSocketNotificationService();
+    Notification n = new Notification(1L, Notification.NotificationType.NEW_MESSAGE, "t", "m", null, null);
+    n.setId(1L);
+    n.setCreatedAt(Instant.now());
+
+    assertDoesNotThrow(() -> service.notifyUser(1L, n));
+  }
+
+  @Test
+  void notifyUser_sendsMessage_whenSessionOpen() throws Exception {
+    WebSocketNotificationService service = new WebSocketNotificationService();
+
+    WebSocketSession session = mock(WebSocketSession.class);
+    when(session.isOpen()).thenReturn(true);
+
+    service.registerSession(1L, session);
+
+    Notification n = new Notification(1L, Notification.NotificationType.NEW_MESSAGE, "Title", "Msg", null, null);
+    n.setId(123L);
+    n.setCreatedAt(Instant.now());
+
+    service.notifyUser(1L, n);
+
+    verify(session, atLeastOnce()).sendMessage(any(TextMessage.class));
+  }
+
+  @Test
+  void notifyUser_removesSession_whenSendFails() throws Exception {
+    WebSocketNotificationService service = new WebSocketNotificationService();
+
+    WebSocketSession session = mock(WebSocketSession.class);
+    when(session.isOpen()).thenReturn(true);
+    doThrow(new IOException("boom"))
+        .doNothing()
+        .when(session).sendMessage(any(TextMessage.class));
+
+    service.registerSession(1L, session);
+
+    Notification n = new Notification(1L, Notification.NotificationType.NEW_MESSAGE, "Title", "Msg", null, null);
+    n.setId(123L);
+    n.setCreatedAt(Instant.now());
+
+    service.notifyUser(1L, n);
+    service.notifyUser(1L, n);
+
+    verify(session, times(1)).sendMessage(any(TextMessage.class));
+  }
+
+  @Test
+  void notifyUnreadCount_sendsMessage_whenSessionOpen() throws Exception {
+    WebSocketNotificationService service = new WebSocketNotificationService();
+
+    WebSocketSession session = mock(WebSocketSession.class);
+    when(session.isOpen()).thenReturn(true);
+
+    service.registerSession(1L, session);
+    service.notifyUnreadCount(1L, 5L);
+
+    verify(session, atLeastOnce()).sendMessage(any(TextMessage.class));
+  }
+
+  @Test
+  void unregisterSession_removesUserEntry_whenLastSessionRemoved() {
+    WebSocketNotificationService service = new WebSocketNotificationService();
+
+    WebSocketSession session = mock(WebSocketSession.class);
+    service.registerSession(1L, session);
+    service.unregisterSession(1L, session);
+
+    Notification n = new Notification(1L, Notification.NotificationType.NEW_MESSAGE, "t", "m", null, null);
+    n.setId(1L);
+    n.setCreatedAt(Instant.now());
+
+    assertDoesNotThrow(() -> service.notifyUser(1L, n));
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/websocket/NotificationWebSocketHandlerTest.java
+++ b/backend/src/test/java/com/example/backend/websocket/NotificationWebSocketHandlerTest.java
@@ -1,0 +1,107 @@
+package com.example.backend.websocket;
+
+import com.example.backend.model.User;
+import com.example.backend.service.AuthService;
+import com.example.backend.service.WebSocketNotificationService;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+class NotificationWebSocketHandlerTest {
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void afterConnectionEstablished_registersSession_whenAuthenticated() throws Exception {
+    WebSocketNotificationService wsService = mock(WebSocketNotificationService.class);
+    AuthService authService = mock(AuthService.class);
+    NotificationWebSocketHandler handler = new NotificationWebSocketHandler(wsService, authService);
+
+    User user = new User("alice", "a@b.com", "p");
+    user.setId(42L);
+    when(authService.getCurrentAuthenticatedUser()).thenReturn(user);
+
+    SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+    ctx.setAuthentication(new UsernamePasswordAuthenticationToken("alice", "x", java.util.List.of()));
+    SecurityContextHolder.setContext(ctx);
+
+    WebSocketSession session = mock(WebSocketSession.class);
+    when(session.getAttributes()).thenReturn(new HashMap<>());
+
+    handler.afterConnectionEstablished(session);
+
+    verify(wsService).registerSession(42L, session);
+    verify(session, never()).close(any());
+  }
+
+  @Test
+  void afterConnectionEstablished_usesHttpSessionFallback_whenNoSecurityContext() throws Exception {
+    WebSocketNotificationService wsService = mock(WebSocketNotificationService.class);
+    AuthService authService = mock(AuthService.class);
+    NotificationWebSocketHandler handler = new NotificationWebSocketHandler(wsService, authService);
+
+    WebSocketSession session = mock(WebSocketSession.class);
+    HttpSession httpSession = mock(HttpSession.class);
+    when(httpSession.getAttribute("userId")).thenReturn("7");
+
+    Map<String, Object> attrs = new HashMap<>();
+    attrs.put("httpSession", httpSession);
+    when(session.getAttributes()).thenReturn(attrs);
+
+    handler.afterConnectionEstablished(session);
+
+    verify(wsService).registerSession(7L, session);
+    verify(session, never()).close(any());
+  }
+
+  @Test
+  void afterConnectionEstablished_closesConnection_whenNoUserId() throws Exception {
+    WebSocketNotificationService wsService = mock(WebSocketNotificationService.class);
+    AuthService authService = mock(AuthService.class);
+    NotificationWebSocketHandler handler = new NotificationWebSocketHandler(wsService, authService);
+
+    WebSocketSession session = mock(WebSocketSession.class);
+    when(session.getAttributes()).thenReturn(new HashMap<>());
+
+    handler.afterConnectionEstablished(session);
+
+    verify(wsService, never()).registerSession(anyLong(), any());
+    verify(session).close(any(CloseStatus.class));
+  }
+
+  @Test
+  void afterConnectionClosed_unregistersSession_whenUserIdResolved() throws Exception {
+    WebSocketNotificationService wsService = mock(WebSocketNotificationService.class);
+    AuthService authService = mock(AuthService.class);
+    NotificationWebSocketHandler handler = new NotificationWebSocketHandler(wsService, authService);
+
+    User user = new User("alice", "a@b.com", "p");
+    user.setId(42L);
+    when(authService.getCurrentAuthenticatedUser()).thenReturn(user);
+
+    SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+    ctx.setAuthentication(new UsernamePasswordAuthenticationToken("alice", "x", java.util.List.of()));
+    SecurityContextHolder.setContext(ctx);
+
+    WebSocketSession session = mock(WebSocketSession.class);
+    when(session.getAttributes()).thenReturn(new HashMap<>());
+
+    handler.afterConnectionClosed(session, CloseStatus.NORMAL);
+
+    verify(wsService).unregisterSession(42L, session);
+  }
+}
+

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../services/auth', () => ({ login: vi.fn(), register: vi.fn() }))
+vi.mock('../services/notifications', () => ({ getUnreadCount: vi.fn() }))
+vi.mock('../services/localNotifications', () => ({ getUnreadLocalCount: vi.fn() }))
+
+vi.mock('../components/EventExplorer', () => ({ default: () => <div>EventExplorerMock</div> }))
+vi.mock('../components/ProfileConfigurator', () => ({ default: () => <div>ProfileConfiguratorMock</div> }))
+
+import App from '../App'
+import * as auth from '../services/auth'
+import * as notifications from '../services/notifications'
+import * as localNotifications from '../services/localNotifications'
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+  window.history.pushState({}, '', '/')
+
+  notifications.getUnreadCount.mockResolvedValue({ ok: true, data: { count: 0 } })
+  localNotifications.getUnreadLocalCount.mockReturnValue(0)
+})
+
+describe('App', () => {
+  it('muestra login por defecto y valida campos requeridos', async () => {
+    render(<App />)
+
+    expect(screen.getByRole('region', { name: /login form/i })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /iniciar/i }))
+
+    expect(auth.login).not.toHaveBeenCalled()
+    expect(screen.getByText('Username is required')).toBeInTheDocument()
+    expect(screen.getByText('Password is required')).toBeInTheDocument()
+  })
+
+  it('permite cambiar a register y valida campos', async () => {
+    render(<App />)
+
+    await userEvent.click(screen.getByRole('button', { name: /crear cuenta/i }))
+
+    expect(screen.getByRole('region', { name: /register form/i })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /^crear cuenta$/i }))
+
+    expect(auth.register).not.toHaveBeenCalled()
+    expect(screen.getByText('Username is required')).toBeInTheDocument()
+    expect(screen.getByText('Email is required')).toBeInTheDocument()
+    expect(screen.getByText('Password is required')).toBeInTheDocument()
+  })
+
+  it('login OK llama al servicio y cambia a explore', async () => {
+    auth.login.mockResolvedValue({ ok: true, status: 200, data: { user: { id: 5 } } })
+
+    render(<App />)
+
+    await userEvent.type(screen.getByLabelText(/nombre de usuario/i), 'pepe')
+    await userEvent.type(screen.getByPlaceholderText(/Introduce tu contrase/i), 'password123')
+
+    await userEvent.click(screen.getByRole('button', { name: /iniciar/i }))
+
+    expect(auth.login).toHaveBeenCalledWith({ username: 'pepe', password: 'password123' })
+
+    expect(await screen.findByRole('region', { name: /explore form/i })).toBeInTheDocument()
+    expect(screen.getByText('EventExplorerMock')).toBeInTheDocument()
+
+    expect(localStorage.getItem('userId')).toBe('5')
+    expect(localStorage.getItem('username')).toBe('pepe')
+  })
+
+  it('register OK llama al servicio y cambia a profile-config', async () => {
+    auth.register.mockResolvedValue({ ok: true, status: 201, data: { user: { id: 7 } } })
+
+    render(<App />)
+
+    await userEvent.click(screen.getByRole('button', { name: /crear cuenta/i }))
+
+    await userEvent.type(screen.getByLabelText(/nombre de usuario/i), 'ana')
+    await userEvent.type(screen.getByLabelText(/correo/i), 'ana@example.com')
+    await userEvent.type(screen.getByPlaceholderText(/Elige una contrase/i), 'password123')
+    await userEvent.type(screen.getByPlaceholderText(/Repite tu contrase/i), 'password123')
+
+    await userEvent.click(screen.getByRole('button', { name: /^crear cuenta$/i }))
+
+    expect(auth.register).toHaveBeenCalledWith({
+      username: 'ana',
+      email: 'ana@example.com',
+      password: 'password123',
+    })
+
+    expect(await screen.findByRole('region', { name: /profile-config form/i })).toBeInTheDocument()
+    expect(screen.getByText('ProfileConfiguratorMock')).toBeInTheDocument()
+
+    expect(localStorage.getItem('userId')).toBe('7')
+    expect(localStorage.getItem('username')).toBe('ana')
+    expect(localStorage.getItem('email')).toBe('ana@example.com')
+  })
+
+  it('suma backend + local para el badge de notificaciones', async () => {
+    window.history.pushState({}, '', '/?dev=explore')
+    notifications.getUnreadCount.mockResolvedValue({ ok: true, data: { count: 2 } })
+    localNotifications.getUnreadLocalCount.mockReturnValue(1)
+
+    render(<App />)
+
+    expect(screen.getByRole('region', { name: /explore form/i })).toBeInTheDocument()
+    expect(await screen.findByText('3')).toBeInTheDocument()
+  })
+})
+

--- a/frontend/src/__tests__/main.test.jsx
+++ b/frontend/src/__tests__/main.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('react-dom/client', () => {
+  return {
+    createRoot: vi.fn(() => ({ render: vi.fn() })),
+  }
+})
+
+vi.mock('../App.jsx', () => ({ default: () => null }))
+
+describe('main.jsx', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    document.body.innerHTML = '<div id="root"></div>'
+  })
+
+  it('monta la app en #root', async () => {
+    const { createRoot } = await import('react-dom/client')
+
+    await import('../main.jsx')
+
+    expect(createRoot).toHaveBeenCalledTimes(1)
+    expect(createRoot).toHaveBeenCalledWith(document.getElementById('root'))
+
+    const root = createRoot.mock.results[0].value
+    expect(root.render).toHaveBeenCalledTimes(1)
+  })
+})
+

--- a/frontend/src/services/__tests__/api.test.js
+++ b/frontend/src/services/__tests__/api.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest'
+
+let request
+let originalFetch
+
+beforeAll(async () => {
+  originalFetch = globalThis.fetch
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  ;({ request } = await import('../api'))
+})
+
+afterAll(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn()
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.clearAllMocks()
+})
+
+describe('api.request', () => {
+  it('hace fetch y parsea JSON', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ hello: 'world' })),
+    })
+
+    const res = await request('/ping')
+
+    expect(res.ok).toBe(true)
+    expect(res.status).toBe(200)
+    expect(res.data).toEqual({ hello: 'world' })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [url, opts] = fetch.mock.calls[0]
+    expect(url).toMatch(/\/ping$/)
+    expect(opts).toEqual(
+      expect.objectContaining({
+        method: 'GET',
+        credentials: 'include',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+      }),
+    )
+  })
+
+  it('stringifica body y respeta method/credentials', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: vi.fn().mockResolvedValue(''),
+    })
+
+    await request('/submit', { method: 'POST', body: { a: 1 }, credentials: 'omit' })
+
+    const [url, opts] = fetch.mock.calls[0]
+    expect(url).toMatch(/\/submit$/)
+    expect(opts.method).toBe('POST')
+    expect(opts.credentials).toBe('omit')
+    expect(opts.body).toBe(JSON.stringify({ a: 1 }))
+  })
+
+  it('permite sobrescribir headers (incluyendo Content-Type)', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: vi.fn().mockResolvedValue(''),
+    })
+
+    await request('/x', { headers: { 'Content-Type': 'text/plain', 'X-Test': '1' } })
+
+    const [, opts] = fetch.mock.calls[0]
+    expect(opts.headers).toEqual(
+      expect.objectContaining({
+        'Content-Type': 'text/plain',
+        'X-Test': '1',
+      }),
+    )
+  })
+
+  it('si la respuesta no es JSON, devuelve texto', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue('NOT_JSON'),
+    })
+
+    const res = await request('/err')
+    expect(res.data).toBe('NOT_JSON')
+  })
+
+  it('si la respuesta es vacía, devuelve null', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue(''),
+    })
+
+    const res = await request('/empty')
+    expect(res.data).toBeNull()
+  })
+})
+

--- a/frontend/src/services/__tests__/auth.test.js
+++ b/frontend/src/services/__tests__/auth.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../api', () => ({ request: vi.fn() }))
+
+import { request } from '../api'
+import { login, register } from '../auth'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+})
+
+describe('auth service', () => {
+  it('login guarda userId y username en localStorage cuando ok', async () => {
+    request.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: { user: { id: 123, username: 'pepe' } },
+    })
+
+    const res = await login({ username: 'pepe', password: 'secret' })
+
+    expect(request).toHaveBeenCalledWith('/auth/login', {
+      method: 'POST',
+      body: { username: 'pepe', password: 'secret' },
+    })
+    expect(res.ok).toBe(true)
+    expect(localStorage.getItem('userId')).toBe('123')
+    expect(localStorage.getItem('username')).toBe('pepe')
+  })
+
+  it('login NO guarda nada si la respuesta no es ok o no hay user', async () => {
+    request.mockResolvedValue({ ok: false, status: 401, data: { message: 'bad' } })
+    await login({ username: 'x', password: 'y' })
+    expect(localStorage.getItem('userId')).toBeNull()
+
+    request.mockResolvedValue({ ok: true, status: 200, data: {} })
+    await login({ username: 'x', password: 'y' })
+    expect(localStorage.getItem('userId')).toBeNull()
+  })
+
+  it('register llama al endpoint correcto', async () => {
+    request.mockResolvedValue({ ok: true, status: 201, data: { message: 'ok' } })
+
+    await register({ username: 'ana', email: 'ana@example.com', password: 'pass' })
+
+    expect(request).toHaveBeenCalledWith('/auth/register', {
+      method: 'POST',
+      body: { username: 'ana', email: 'ana@example.com', password: 'pass' },
+    })
+  })
+})
+

--- a/frontend/src/services/__tests__/chat.test.js
+++ b/frontend/src/services/__tests__/chat.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../api', () => ({ request: vi.fn() }))
+
+import { request } from '../api'
+import { getChatMessages, sendChatMessage, checkParticipant } from '../chat'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('chat service', () => {
+  it('getChatMessages construye endpoint de chat', async () => {
+    request.mockResolvedValue({ ok: true })
+    await getChatMessages(3)
+    expect(request).toHaveBeenCalledWith('/events/3/chat/messages', { method: 'GET' })
+  })
+
+  it('sendChatMessage envía el mensaje', async () => {
+    request.mockResolvedValue({ ok: true })
+    await sendChatMessage(3, 'hola')
+    expect(request).toHaveBeenCalledWith('/events/3/chat/messages', { method: 'POST', body: { text: 'hola' } })
+  })
+
+  it('checkParticipant construye endpoint de participants', async () => {
+    request.mockResolvedValue({ ok: true })
+    await checkParticipant(3, 99)
+    expect(request).toHaveBeenCalledWith('/events/3/participants/99', { method: 'GET' })
+  })
+})
+

--- a/frontend/src/services/__tests__/directMessages.test.js
+++ b/frontend/src/services/__tests__/directMessages.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../api', () => ({ request: vi.fn() }))
+
+import { request } from '../api'
+import { getChats, searchUsers, getDirectMessages, sendDirectMessage } from '../directMessages'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('directMessages service', () => {
+  it('getChats llama a /messages/chats', async () => {
+    request.mockResolvedValue({ ok: true })
+    await getChats()
+    expect(request).toHaveBeenCalledWith('/messages/chats', { method: 'GET' })
+  })
+
+  it('searchUsers encodea el query', async () => {
+    request.mockResolvedValue({ ok: true })
+    await searchUsers('a/b c?')
+    expect(request).toHaveBeenCalledWith('/messages/users/search?q=a%2Fb%20c%3F', { method: 'GET' })
+  })
+
+  it('getDirectMessages y sendDirectMessage usan /messages/users/:id', async () => {
+    request.mockResolvedValue({ ok: true })
+
+    await getDirectMessages(2)
+    expect(request).toHaveBeenCalledWith('/messages/users/2', { method: 'GET' })
+
+    await sendDirectMessage(2, 'hola')
+    expect(request).toHaveBeenCalledWith('/messages/users/2', { method: 'POST', body: { text: 'hola' } })
+  })
+})
+

--- a/frontend/src/services/__tests__/events.test.js
+++ b/frontend/src/services/__tests__/events.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../api', () => ({ request: vi.fn() }))
+
+import { request } from '../api'
+import { listEvents, getEvent, joinEvent, leaveEvent, createEvent } from '../events'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('events service', () => {
+  it('listEvents sin params usa /events', async () => {
+    request.mockResolvedValue({ ok: true })
+    await listEvents()
+    expect(request).toHaveBeenCalledWith('/events', { method: 'GET' })
+  })
+
+  it('listEvents construye query string con filtros', async () => {
+    request.mockResolvedValue({ ok: true })
+
+    await listEvents({
+      q: 'run',
+      location: 'NY',
+      sports: ['Tennis', 'Cycling'],
+      days: ['Mon', 'Tue'],
+      timeFrom: '08:00',
+      timeTo: '10:00',
+    })
+
+    expect(request).toHaveBeenCalledWith(
+      '/events?q=run&location=NY&sports=Tennis%2CCycling&days=Mon%2CTue&timeFrom=08%3A00&timeTo=10%3A00',
+      { method: 'GET' },
+    )
+  })
+
+  it('getEvent/joinEvent/leaveEvent llaman a sus endpoints', async () => {
+    request.mockResolvedValue({ ok: true })
+
+    await getEvent(7)
+    expect(request).toHaveBeenCalledWith('/events/7', { method: 'GET' })
+
+    await joinEvent(7)
+    expect(request).toHaveBeenCalledWith('/events/7/join', { method: 'POST' })
+
+    await leaveEvent(7)
+    expect(request).toHaveBeenCalledWith('/events/7/leave', { method: 'POST' })
+  })
+
+  it('createEvent envía payload', async () => {
+    request.mockResolvedValue({ ok: true })
+
+    const payload = { title: 'Run', sport: 'Running' }
+    await createEvent(payload)
+
+    expect(request).toHaveBeenCalledWith('/events', { method: 'POST', body: payload })
+  })
+})
+

--- a/frontend/src/services/__tests__/localNotifications.test.js
+++ b/frontend/src/services/__tests__/localNotifications.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  getLocalNotifications,
+  addLocalNotification,
+  markLocalNotificationAsRead,
+  markAllLocalNotificationsAsRead,
+  deleteLocalNotification,
+  clearAllLocalNotifications,
+  getUnreadLocalCount,
+} from '../localNotifications'
+
+let dispatchSpy
+
+beforeEach(() => {
+  localStorage.clear()
+  dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+})
+
+afterEach(() => {
+  dispatchSpy.mockRestore()
+  vi.clearAllMocks()
+})
+
+describe('localNotifications', () => {
+  it('por defecto devuelve [] si no hay nada', () => {
+    expect(getLocalNotifications()).toEqual([])
+  })
+
+  it('usa userId para la clave y dispara evento al añadir', () => {
+    localStorage.setItem('userId', '7')
+
+    const notif = addLocalNotification({ type: 'info', message: 'hola' })
+
+    expect(notif).toEqual(expect.objectContaining({ type: 'info', message: 'hola', read: false, isLocal: true }))
+
+    const raw = localStorage.getItem('local_notifications:7')
+    expect(raw).not.toBeNull()
+    expect(JSON.parse(raw)).toHaveLength(1)
+
+    expect(dispatchSpy).toHaveBeenCalled()
+    const evt = dispatchSpy.mock.calls[0][0]
+    expect(evt.type).toBe('localNotificationAdded')
+  })
+
+  it('si el JSON guardado está roto, getLocalNotifications devuelve []', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    localStorage.setItem('local_notifications:anon', '{bad json')
+
+    expect(getLocalNotifications()).toEqual([])
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('recorta a 50 notificaciones como máximo', () => {
+    const seed = Array.from({ length: 55 }, (_, i) => ({ id: `n${i}`, read: false }))
+    localStorage.setItem('local_notifications:anon', JSON.stringify(seed))
+
+    addLocalNotification({ type: 'info', message: 'nueva' })
+
+    const stored = JSON.parse(localStorage.getItem('local_notifications:anon'))
+    expect(stored).toHaveLength(50)
+  })
+
+  it('markLocalNotificationAsRead marca una como leída y dispara evento', () => {
+    const seed = [{ id: 'a', read: false }, { id: 'b', read: false }]
+    localStorage.setItem('local_notifications:anon', JSON.stringify(seed))
+
+    markLocalNotificationAsRead('a')
+
+    const stored = JSON.parse(localStorage.getItem('local_notifications:anon'))
+    expect(stored.find(n => n.id === 'a').read).toBe(true)
+    expect(dispatchSpy).toHaveBeenCalled()
+    expect(dispatchSpy.mock.calls[0][0].type).toBe('localNotificationUpdated')
+  })
+
+  it('markAllLocalNotificationsAsRead marca todas como leídas', () => {
+    const seed = [{ id: 'a', read: false }, { id: 'b', read: true }]
+    localStorage.setItem('local_notifications:anon', JSON.stringify(seed))
+
+    markAllLocalNotificationsAsRead()
+
+    const stored = JSON.parse(localStorage.getItem('local_notifications:anon'))
+    expect(stored.every(n => n.read)).toBe(true)
+  })
+
+  it('deleteLocalNotification elimina una y clearAllLocalNotifications borra todas', () => {
+    const seed = [{ id: 'a', read: false }, { id: 'b', read: false }]
+    localStorage.setItem('local_notifications:anon', JSON.stringify(seed))
+
+    deleteLocalNotification('a')
+    let stored = JSON.parse(localStorage.getItem('local_notifications:anon'))
+    expect(stored.map(n => n.id)).toEqual(['b'])
+
+    clearAllLocalNotifications()
+    expect(localStorage.getItem('local_notifications:anon')).toBeNull()
+  })
+
+  it('getUnreadLocalCount cuenta no leídas', () => {
+    const seed = [{ id: 'a', read: false }, { id: 'b', read: true }, { id: 'c', read: false }]
+    localStorage.setItem('local_notifications:anon', JSON.stringify(seed))
+
+    expect(getUnreadLocalCount()).toBe(2)
+  })
+})

--- a/frontend/src/services/__tests__/notifications.test.js
+++ b/frontend/src/services/__tests__/notifications.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../api', () => ({ request: vi.fn() }))
+
+import { request } from '../api'
+import { getNotifications, getUnreadCount, markAsRead, markAllAsRead, deleteNotification } from '../notifications'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('notifications service', () => {
+  it('GET endpoints usan rutas correctas', async () => {
+    request.mockResolvedValue({ ok: true })
+
+    await getNotifications()
+    expect(request).toHaveBeenCalledWith('/notifications')
+
+    await getUnreadCount()
+    expect(request).toHaveBeenCalledWith('/notifications/unread-count')
+  })
+
+  it('markAsRead/markAllAsRead/deleteNotification usan métodos correctos', async () => {
+    request.mockResolvedValue({ ok: true })
+
+    await markAsRead(10)
+    expect(request).toHaveBeenCalledWith('/notifications/10/read', { method: 'PUT' })
+
+    await markAllAsRead()
+    expect(request).toHaveBeenCalledWith('/notifications/read-all', { method: 'PUT' })
+
+    await deleteNotification(10)
+    expect(request).toHaveBeenCalledWith('/notifications/10', { method: 'DELETE' })
+  })
+})
+

--- a/frontend/src/services/__tests__/profile.test.js
+++ b/frontend/src/services/__tests__/profile.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../api', () => ({ request: vi.fn() }))
+
+import { request } from '../api'
+import { saveProfile, getProfile, uploadAvatar } from '../profile'
+
+let originalFetch
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  originalFetch = globalThis.fetch
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('profile service', () => {
+  it('saveProfile normaliza profileImage -> avatarUrl', async () => {
+    request.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: { profileImage: '/uploads/a.png' },
+    })
+
+    const res = await saveProfile(1, { sports: [], bio: 'hola', profileImage: '/uploads/a.png' })
+
+    expect(request).toHaveBeenCalledWith('/profile/1', {
+      method: 'POST',
+      body: { sports: [], bio: 'hola', profileImage: '/uploads/a.png' },
+    })
+    expect(res.data.avatarUrl).toBe('/uploads/a.png')
+  })
+
+  it('getProfile normaliza profileImage -> avatarUrl', async () => {
+    request.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: { profileImage: '/uploads/b.png' },
+    })
+
+    const res = await getProfile(2)
+    expect(request).toHaveBeenCalledWith('/users/2', { method: 'GET' })
+    expect(res.data.avatarUrl).toBe('/uploads/b.png')
+  })
+
+  it('uploadAvatar requiere file', async () => {
+    await expect(uploadAvatar(1)).rejects.toThrow('File is required')
+  })
+
+  it('uploadAvatar usa multipart y normaliza profileImage -> avatarUrl', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ profileImage: '/uploads/c.png' })),
+    })
+
+    const file = new File(['x'], 'avatar.png', { type: 'image/png' })
+    const res = await uploadAvatar(3, file)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [url, opts] = fetch.mock.calls[0]
+    expect(url).toMatch(/\/profile\/3\/avatar$/)
+    expect(opts).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: expect.any(FormData),
+      }),
+    )
+    expect(res.ok).toBe(true)
+    expect(res.data.avatarUrl).toBe('/uploads/c.png')
+  })
+
+  it('uploadAvatar devuelve texto si la respuesta no es JSON', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue('NOT_JSON'),
+    })
+
+    const file = new File(['x'], 'avatar.png', { type: 'image/png' })
+    const res = await uploadAvatar(3, file)
+    expect(res.data).toBe('NOT_JSON')
+  })
+})
+

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,6 +14,12 @@ export default defineConfig({
     css: true, // permite importar CSS en tests
     coverage: {
       reporter: ['text', 'html', 'json-summary', 'lcov'],
+      include: ['src/**/*.{js,jsx}'],
+      exclude: [
+        'src/setupTests.js',
+        'src/**/__tests__/**',
+        'src/**/*.test.{js,jsx}',
+      ],
     },
   },
 })


### PR DESCRIPTION
Añade tests unitarios para los servicios del frontend (capa src/services) para aumentar el coverage.
Nuevos tests en social-fitness/frontend/src/services/__tests__/:
api.test.js: parsing de respuestas (JSON/texto/vacío), body, headers, credentials.
auth.test.js: login (guardado en localStorage) y register.
events.test.js: construcción de query params y endpoints /events.
directMessages.test.js: endpoints /messages/* y encoding del query.
notifications.test.js: endpoints y métodos correctos (GET/PUT/DELETE).
chat.test.js: endpoints de chat por evento.
profile.test.js: normalización profileImage -> avatarUrl y uploadAvatar (FormData + errores).
localNotifications.test.js: CRUD en localStorage, límite de 50, eventos CustomEvent, conteo no leídas.
Resultado: sube el coverage global del frontend y deja frontend/src/services con cobertura alta.